### PR TITLE
Fixes for current UCAS layout

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,11 @@ require File.join(File.dirname(__FILE__), 'settings')
 namespace :ucas do
   task :metadata do
     UCAS::Application.log("Fetching course metadata from database...")
-    scraper = UCAS::Scraper.new(UCAS_PERSONAL_ID, UCAS_USERNAME, UCAS_PASSWORD)
+    scraper = UCAS::Scraper.new(UCAS_PERSONAL_ID, UCAS_PASSWORD)
     results = scraper.fetch_metadata
     results.each do |entry|
-      UCAS::Application.log("Found course #{entry[:course]} (#{entry[:code]}) at #{entry[:university]}. Saving...")
-      UCAS::Datastore.set(entry[:code], entry)
+      UCAS::Application.log("Found course #{entry[:course]} (#{entry[:courseCode]}) at #{entry[:university]}. Saving...")
+      UCAS::Datastore.set(entry[:universityCode] + '-' + entry[:courseCode], entry)
     end
   end
 end

--- a/lib/application.rb
+++ b/lib/application.rb
@@ -3,7 +3,7 @@ require 'logger'
 
 module UCAS
   class Application
-    @@version = "2.0"
+    @@version = "2.1"
     
     def self.version
       @@version

--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -5,18 +5,17 @@ require 'open-uri'
 
 module UCAS
   class Scraper
-    TRACK_URL = 'https://track.ucas.com/ucastrack/Login.jsp'
-    def initialize(personal_id, username, password)
+    TRACK_URL = 'https://track.ucas.com/'
+    def initialize(personal_id, password)
       
-      if personal_id.empty? or username.empty? or password.empty?
-        raise UCAS::ScraperException, "You must provide a personal ID, username and password"
+      if personal_id.empty? or password.empty?
+        raise UCAS::ScraperException, "You must provide a personal ID and password"
         return
       end
       
       @agent = Mechanize.new
       @settings = {
         personal_id: personal_id,
-        username: username,
         password: password
       }
       
@@ -59,59 +58,73 @@ module UCAS
         @agent.get(TRACK_URL)
         
         # Fill in the login form, and then submit it
-        @agent.page.forms[0]["appNo"] = @settings[:personal_id]
-        @agent.page.forms[0]["username"] = @settings[:username]
-        @agent.page.forms[0]["appPassword"] = @settings[:password]
-        @agent.page.forms[0].submit(@agent.page.forms[0].button_with(:value => "login"))
+        @agent.page.forms[0]["PersonalId"] = @settings[:personal_id]
+        @agent.page.forms[0]["Password"] = @settings[:password]
+        @agent.page.forms[0].submit(@agent.page.forms[0].button_with(:value => "Log in"))
         
         # Check that we successfully logged in, and raise an exception if not
-        if @agent.page.search('.errormsg').any?
+        if @agent.page.search('.field-validation-error').any?
           raise UCAS::ScraperException, "The login details provided were incorrect"
         end
       end
       
       def go_to_choices
-        @agent.page.link_with(text: "choices ").click
-      end
-      
-      def get_course_name(code, institution)
-          document = Nokogiri::HTML(open("http://www.meanboyfriend.com/readtolearn/ucas_code_search/?course_code=#{code}&catalogue_year=2013"))
-          document.css("institution[name='#{institution}'] course name").text()
+        @agent.page.link_with(text: "Your choices").click
       end
       
       def parse
-        choice_rows = @agent.page.search('td.trackinfo')
-        course_codes = @agent.page.search('a.track')
+
+        choice_rows = @agent.page.search('.offer-summary')
+        course_codes = @agent.page.search('.offer-summary .offer-su .half .subheader .detail')
+
         results = []
 
+        i = 0
+
         course_codes.each do |field|
+
           result = {}
-            result[:code] = field.text.strip
-            result[:decision] = choice_rows[2].text.strip!
-            5.times { choice_rows.shift }
+            result[:universityCode] = choice_rows[i].search('.offer-su .half .header .detail')[0].text
+            result[:courseCode] = field.text
+            result[:decision] = choice_rows[i].search('.offer-su .half .header')[1].text.strip!
           
+          i += 1
+
           results << result
+
         end
+
         results
+
       end
       
       def parse_course_data
-        choice_rows = @agent.page.search('td.trackinfo')
-        course_codes = @agent.page.search('a.track')
+
+        choice_rows = @agent.page.search('.offer-summary')
+        course_codes = @agent.page.search('.offer-summary .offer-su .half .subheader .detail')
+
         results = []
+
         i = 0
+
         course_codes.each do |field|
-            result = {}
-            result[:code] = field.text.strip!
-            result[:university] = choice_rows.shift.text.strip!
-            result[:starting] = choice_rows.shift.text.strip!
-            result[:decision] = choice_rows.shift.text.strip!
-          2.times { choice_rows.shift }
-          
-          result[:course] = get_course_name(result[:code], result[:university])
+
+          result = {}
+            result[:universityCode] = choice_rows[i].search('.offer-su .half .header .detail')[0].text
+            result[:courseCode] = field.text
+            result[:university] = choice_rows[i].search('.offer-su .half .header')[0].children.first.text.strip!
+            result[:course] = choice_rows[i].search('.offer-su .half .subheader')[0].children.first.text.strip!
+            result[:starting] = choice_rows[i].search('.offer-su .half').xpath('//label[@for="choice_StartDate"]/..').children.last.text.strip!
+            result[:decision] = choice_rows[i].search('.offer-su .half .header')[1].text.strip!
+
+          i += 1
+
           results << result
+
         end
+
         results
+
       end
       
   end

--- a/settings.rb.example
+++ b/settings.rb.example
@@ -1,5 +1,4 @@
 UCAS_PERSONAL_ID = "<x>"
-UCAS_USERNAME = "<x>"
 UCAS_PASSWORD = "<x>" # Don't worry, only you can see this
 
 TWILIO_SID = "<x>"

--- a/ucas.rb
+++ b/ucas.rb
@@ -4,12 +4,12 @@ Dir[File.dirname(__FILE__) + '/lib/*.rb'].each {|file| require file }
 # Bring in the settings constants from settings.rb
 require File.join(File.dirname(__FILE__), 'settings')
 
-scraper = UCAS::Scraper.new(UCAS_PERSONAL_ID, UCAS_USERNAME, UCAS_PASSWORD)
+scraper = UCAS::Scraper.new(UCAS_PERSONAL_ID, UCAS_PASSWORD)
 results = scraper.scrape
 results.each do |result|
   
   begin
-    entry = UCAS::Datastore.get(result[:code])
+    entry = UCAS::Datastore.get(result[:universityCode] + "-" + result[:courseCode])
     
   rescue Exception => e
     UCAS::Application.error("There was an error in reading from Redis: #{e.message}")
@@ -20,11 +20,11 @@ results.each do |result|
     # The decision for that university has changed - hooray!
     
     entry[:decision] = result[:decision] # Get ready to save the new application status
-    UCAS::Application.log("Change of status for the course #{entry[:course]} at #{entry[:university]}: '#{entry[:decision]}' (#{entry[:code]})")
+    UCAS::Application.log("Change of status for the course #{entry[:course]} at #{entry[:university]}: '#{entry[:decision]}' (#{entry[:courseCode]})")
     UCAS::Notifier.notify(entry)
     
     begin
-      UCAS::Datastore.set(entry[:code], entry)
+      UCAS::Datastore.set(entry[:courseCode], entry)
     rescue Exception => e
       UCAS::Application.error("There was an error in Redis: #{e.message}")
       raise
@@ -32,6 +32,6 @@ results.each do |result|
       
   else
     # Nothing has changed since last time
-    UCAS::Application.log("There has been no change of status for the course '#{entry[:course]}' (#{entry[:code]}) at #{entry[:university]}.")
+    UCAS::Application.log("There has been no change of status for the course '#{entry[:course]}' (#{entry[:courseCode]}) at #{entry[:university]}.")
   end
 end


### PR DESCRIPTION
Scraper wasn't working any more (looks like a different version of the site?). I've made it work with the current site now so I figured I should share my fixes. 

Since I neglected to bother with frequent commits (oops ;)) I have:
- Fixed the actual scraping
- Switched the datastore key to a UniversityRef-CourseCode format, not sure if codes have changed or something but it didn't like 5 of the same course codes at different universities? 
- Removed the need for usernames - UCAS track doesn't use these, just the ID number and password

p.s. thanks for this, now I don't need to keep checking the track page myself!
